### PR TITLE
feat: Separate SDK initialize function

### DIFF
--- a/android/src/main/java/com/reactlibrary/FacebookAppLinkModule.java
+++ b/android/src/main/java/com/reactlibrary/FacebookAppLinkModule.java
@@ -26,8 +26,6 @@ public class FacebookAppLinkModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void fetchUrl(final Promise promise) {
         try {
-            FacebookSdk.setAutoInitEnabled(true);
-            FacebookSdk.fullyInitialize();
             AppLinkData.fetchDeferredAppLinkData(this.reactContext.getApplicationContext(),
                 new AppLinkData.CompletionHandler() {
                 @Override
@@ -42,5 +40,11 @@ public class FacebookAppLinkModule extends ReactContextBaseJavaModule {
         } catch (Exception e) {
             promise.reject("error", e.getMessage(), e);
         }
+    }
+
+    @ReactMethod
+    public void initializeSDK() {
+        FacebookSdk.setAutoInitEnabled(true);
+        FacebookSdk.fullyInitialize();
     }
 }

--- a/ios/FacebookAppLink.m
+++ b/ios/FacebookAppLink.m
@@ -10,8 +10,6 @@ RCT_REMAP_METHOD(fetchUrl,
                  rejecter:(RCTPromiseRejectBlock)reject)
 {
   dispatch_async(dispatch_get_main_queue(), ^{
-    [FBSDKSettings setAutoInitEnabled:YES];
-    [FBSDKApplicationDelegate initializeSDK:nil];
     [FBSDKAppLinkUtility fetchDeferredAppLink:^(NSURL *url, NSError *error) {
       if (error) {
         reject(@"error", @"Fail to fetch deferred deeplink", error);
@@ -23,6 +21,12 @@ RCT_REMAP_METHOD(fetchUrl,
       resolve(nil);
     }];
   });
+}
+
+RCT_EXPORT_METHOD(initializeSDK)
+{
+  [FBSDKSettings setAutoInitEnabled:YES];
+  [FBSDKApplicationDelegate initializeSDK:nil];
 }
 
 @end

--- a/src/FaceBookAppLink.ts
+++ b/src/FaceBookAppLink.ts
@@ -17,6 +17,11 @@ const fetchUrl: () => Promise<string | undefined> = () => {
   return _fetchUrl;
 };
 
+const initializeSDK = () => {
+  NativeModules.FacebookAppLink.initializeSDK();
+};
+
 export default {
   fetchUrl,
+  initializeSDK,
 };

--- a/src/FaceBookAppLink.web.ts
+++ b/src/FaceBookAppLink.web.ts
@@ -5,4 +5,5 @@
  */
 export default {
   fetchUrl: () => Promise.resolve(undefined),
+  initializeSDK: () => {},
 };


### PR DESCRIPTION
There is no need for SDK initialization if AutoLogAppEventsEnabled is not set to false in project,

Separate facebookSDK initialization from fetchUrl.